### PR TITLE
ログイン機能の追加（認証のみ・認可未実装）

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ repositories {
 dependencies {
     //Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    //SpringSecurity
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     //Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/portfolio/taskapp/MyTaskManager/auth/config/SecurityConfig.java
+++ b/src/main/java/com/portfolio/taskapp/MyTaskManager/auth/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.portfolio.taskapp.MyTaskManager.auth.config;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import com.portfolio.taskapp.MyTaskManager.auth.service.UserAccountDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  private final UserAccountDetailsService accountDetailsService;
+
+  @Autowired
+  public SecurityConfig(UserAccountDetailsService accountDetailsService) {
+    this.accountDetailsService = accountDetailsService;
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/login", "/css/**", "/js/**").permitAll()
+            .requestMatchers(HttpMethod.POST, "/users/register").permitAll()
+            .anyRequest().permitAll()
+        )
+        .formLogin(withDefaults());
+
+    return http.build();
+  }
+
+}

--- a/src/main/java/com/portfolio/taskapp/MyTaskManager/auth/model/UserAccountDetails.java
+++ b/src/main/java/com/portfolio/taskapp/MyTaskManager/auth/model/UserAccountDetails.java
@@ -1,0 +1,37 @@
+package com.portfolio.taskapp.MyTaskManager.auth.model;
+
+import com.portfolio.taskapp.MyTaskManager.domain.entity.UserAccount;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class UserAccountDetails implements UserDetails {
+
+  private final UserAccount userAccount;
+
+  public UserAccountDetails(UserAccount userAccount) {
+    this.userAccount = userAccount;
+  }
+
+  // 一律のアクセス制御のため権限は設定していません
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of();
+  }
+
+  @Override
+  public String getPassword() {
+    return userAccount.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return userAccount.getEmail();
+  }
+
+  public UserAccount getAccount() {
+    return userAccount;
+  }
+
+}

--- a/src/main/java/com/portfolio/taskapp/MyTaskManager/auth/repository/UserAccountRepository.java
+++ b/src/main/java/com/portfolio/taskapp/MyTaskManager/auth/repository/UserAccountRepository.java
@@ -1,0 +1,12 @@
+package com.portfolio.taskapp.MyTaskManager.auth.repository;
+
+import com.portfolio.taskapp.MyTaskManager.domain.entity.UserAccount;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface UserAccountRepository {
+
+  UserAccount findAccountByEmail(@Param("email") String email);
+
+}

--- a/src/main/java/com/portfolio/taskapp/MyTaskManager/auth/service/UserAccountDetailsService.java
+++ b/src/main/java/com/portfolio/taskapp/MyTaskManager/auth/service/UserAccountDetailsService.java
@@ -1,0 +1,33 @@
+package com.portfolio.taskapp.MyTaskManager.auth.service;
+
+import com.portfolio.taskapp.MyTaskManager.auth.model.UserAccountDetails;
+import com.portfolio.taskapp.MyTaskManager.auth.repository.UserAccountRepository;
+import com.portfolio.taskapp.MyTaskManager.domain.entity.UserAccount;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class UserAccountDetailsService implements UserDetailsService {
+
+  private final UserAccountRepository repository;
+
+  @Autowired
+  public UserAccountDetailsService(UserAccountRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    UserAccount account = repository.findAccountByEmail(email);
+    if (account == null) {
+      log.warn("Login failed. Invalid credentials provided");
+      throw new UsernameNotFoundException("認証に失敗しました");
+    }
+    return new UserAccountDetails(account);
+  }
+}

--- a/src/main/resources/mapper/UserAccountRepository.xml
+++ b/src/main/resources/mapper/UserAccountRepository.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.portfolio.taskapp.MyTaskManager.auth.repository.UserAccountRepository">
+
+  <select id="findAccountByEmail"
+    parameterType="String"
+    resultType="com.portfolio.taskapp.MyTaskManager.domain.entity.UserAccount">
+    SELECT public_id, email, password
+    FROM user_accounts
+    WHERE email =#{email}
+  </select>
+
+</mapper>


### PR DESCRIPTION
## 実装内容
[ログイン機能の追加（認証のみ・認可未実装）](https://github.com/Lika-H210/MyTaskManager/commit/cd80e31af87e7def95433229b9015b1d24b99d96)
**概要**
**ユーザーが登録済みのメールアドレスとパスワードでログインできるようにしました**

**詳細**
authパッケージにてログイン関係のクラス・インターフェースを実装
- 依存関係にSpringSecurityを導入
- SecurityConfig ：Spring Securityの設定クラスです。
　　　　　　　　/loginと/users/register（ユーザ登録）は認証不要として個別設定。（登録処理はこの後実装します）
　　　　　　　　formLogin()でデフォルトのログイン画面を使用し動作確認しています。（フロント実装後修正します）
　　　　　　　　BCryptPasswordEncoderでハッシュ化したパスワードを認証に使用しています。

- UserAccountDetails ：Spring Security の UserDetails 実装クラスです。
　　　　　　　　　　　認証対象のユーザー情報（メールアドレス、パスワード）を渡します。
　　　　　　　　　　　※usernameはemailをpasswordはpasswordを参照します。

- UserAccountDetailsService ：UserDetailsService の実装クラスを実装しました。
　　　　　　　　　　　　　　入力されたemailを元にDBからユーザー情報を取得し、認証用の UserDetails を返します

- UserAccountRepository(.xml) ：取得したログイン情報のemailで登録情報を取得します。
　　　　　　　　　　　　　　※emailとpasswardとpublicIdのみを取得し返します。

※ユーザー登録では、passwordをBCrypt でハッシュ化し登録予定のため、認証もpasswordをハッシュ化して検証しています。
　現時点では「認証（ログイン）」機能のみ実装しています。
　「認可（アクセス制限）」は未対応でanyRequest().permitAll()とし、各種登録・更新処理を実装後に認可設定に移行予定です。

## 実行確認
### 認証成功
※認証後の画面はないためerrorページがアウトプットされています。
https://github.com/user-attachments/assets/7661fceb-985a-4d4b-a073-517a0e3b8503

### password間違え
https://github.com/user-attachments/assets/d6a9f326-2e87-4be0-b111-a0dfd16fe827

### email間違え
https://github.com/user-attachments/assets/c044b4a2-a88e-4985-8145-6d65b91cfecb
