### PR TITLE
add: Docker環境でアプリ起動するための関連ファイルを追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Build / Gradle
+build
+.gradle
+.idea
+.run
+
+# Git and docs
+.git
+.gitignore
+README.md
+HELP.md
+
+# Environment files
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# ===== ビルド用ステージ =====
+FROM gradle:8.14.3-jdk21 AS build
+WORKDIR /app
+COPY . .
+RUN ./gradlew build -x test
+
+# ===== 実行用ステージ =====
+FROM openjdk:21-jdk-slim
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # MyTaskManager
 
+## はじめに
+
 本リポジトリは、個人ユーザー向けタスク管理アプリのバックエンド実装です。
 
-※デモ用の簡易フロントを同梱しています。
+本リポジトリのコードは学習・ポートフォリオ目的で提供しており、  
+利用に関するトラブル等については責任を負いかねますのでご了承ください。
 
 ## 背景
 
@@ -54,16 +57,65 @@
 ## インストール・起動手順
 
 <details>
-<summary> インストール・起動手順（クリックして展開）</summary>
+<summary> Dockerを利用する場合 </summary>
 
-### はじめに
-
-このプロジェクトのコードは学習・ポートフォリオ目的で提供しています。  
-プロジェクトの実行によって発生したいかなる問題についても責任を負いかねます。
+以下は、Dockerがインストール済みであることを前提にした起動方法です。
 
 ### 1. リポジトリをクローン
 
-GitHubからこのリポジトリを任意のフォルダにクローンします。
+任意のフォルダにリポジトリをクローンします。
+
+```bash
+git clone https://github.com/Lika-H210/MyTaskManager.git
+cd MyTaskManager
+```
+
+### 2. Docker Composeでアプリを起動
+
+```bash
+docker compose up -d
+```
+
+- 初回起動時はコンテナが作成され、DBも構築されます。
+- 既にコンテナが存在する場合は再利用して起動します。
+
+**補足:**
+
+- Spring Boot はポート 8080、MySQL はホスト側 3307 を使用します。
+- 既に使用中の場合は `docker-compose.yml` 内のホスト側ポートを変更してください。
+
+### 3. 動作確認
+
+- ブラウザからの動作確認：http://localhost:8080/login.html
+
+    - 下記デモユーザー情報でのログインも可能です。
+        - Email: demo@example.com
+        - パスワード: demo_password  
+          <br>
+- API仕様書の確認：http://localhost:8080/swagger-ui/index.html
+
+### Docker停止・終了
+
+- 一時的に停止させる場合（再開可能）
+
+```bash
+docker compose stop
+```
+
+- 完全に終了し、コンテナを削除
+
+```bash
+docker compose down
+```
+
+</details> 
+
+<details>
+<summary> Dockerを利用しない場合 </summary>
+
+### 1. リポジトリをクローン
+
+任意のフォルダにリポジトリをクローンします。
 
 ```bash
 git clone https://github.com/Lika-H210/MyTaskManager.git
@@ -108,19 +160,13 @@ SpringBootを起動します。
 
 ### 5. 動作確認
 
-- ブラウザからの動作確認：
-  [ログイン画面](http://localhost:8080/login.html)
+- ブラウザからの動作確認：http://localhost:8080/login.html
 
-- API仕様書の確認：
-  [Swagger UI](http://localhost:8080/swagger-ui/index.html)
-
-**補足:**
-
-- ブラウザでの動作確認では、デモユーザーを使用したログインも可能です。
-- デモユーザーでもすべてのAPIを実行可能です。（ユーザーの削除処理を除く）
-- デモユーザー情報：
-    - ID: demo@example.com
-    - パスワード: demo_password
+    - 下記デモユーザー情報でのログインも可能です。
+        - Email: demo@example.com
+        - パスワード: demo_password  
+          <br>
+- API仕様書の確認：http://localhost:8080/swagger-ui/index.html
 
 </details> 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java'
-    id 'war'
     id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -41,8 +40,6 @@ dependencies {
     implementation 'org.flywaydb:flyway-mysql:11.12.0'
     //MyBatis
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
-    //Tomcat
-    providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
     //Open API
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     //Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+services:
+  db:
+    image: mysql:8.0
+    container_name: my_task_db
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password
+      MYSQL_DATABASE: task_management
+    ports:
+      - "3307:3306"
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
+  app:
+    build: .
+    container_name: my_task_app
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/task_management
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: root_password
+      SPRING_FLYWAY_LOCATIONS: classpath:db/migration/schema,classpath:db/migration/data
+      SPRING_FLYWAY_ENABLED: "true"
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
## 追加内容
- Docker環境でDBの構築とアプリの起動を行うための各種ファイルの作成。

## 目的
- Docker環境で簡易に実行環境を構築できるようにすることで、アプリの動作確認などを誰でも容易にできる様にする。

## 詳細
- docker-compose.ymlとDockerfileの作成。
  - MySQLのポートはMySQLがローカルで動いている場合を加味しホスト側ポートを3307にしています。
- .dockerignoreを追加し、不要なファイル読み込みを回避。
- READMEにDocker環境を利用したインストール手順を追記
  - 動作確認など共通項目の修正箇所はDocker環境がない場合の手順も修正しています。

## 実行結果

- 本ブランチのクローン作成→実行
<img width="1291" height="514" alt="image" src="https://github.com/user-attachments/assets/4a46bf49-6a4e-4ad6-b7e0-ec331219e61b" />
<img width="1089" height="691" alt="image" src="https://github.com/user-attachments/assets/3f6b5a05-a8ce-4348-bdf2-689a49c0fdce" />

- アプリログイン確認

https://github.com/user-attachments/assets/e7d2d480-d310-441b-8666-418e58fe05c9


- 停止処理→再実行→終了削除
<img width="1219" height="776" alt="image" src="https://github.com/user-attachments/assets/dffabd0b-f43a-40b2-8e05-3b4b6dbc18ea" />
